### PR TITLE
make syntax for doc-tests more concise

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,14 +38,16 @@ It's recommended to add `./tests/Doc` to your `.gitignore`.
 Writing DocTests
 ----------------
 
+Tests start with for spaces!
+
 ```elm
 {-| returns the sum of two int.
 
     >>> add 41 1
-    === 42
+    42
 
     >>> add 3 3
-    === 6
+    6
 -}
 add : Int -> Int -> Int
 add =
@@ -58,14 +60,14 @@ add =
     ...     [ 41
     ...     , 1
     ...     ]
-    === [ 1
-    ... , 41
-    ... ]
+    [ 1
+    , 41
+    ]
 
     >>> rev [1, 2, 3]
     ... |> List.map toString
     ... |> String.join ""
-    === "321"
+    "321"
 -}
 rev : List a -> List a
 rev =

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ It's recommended to add `./tests/Doc` to your `.gitignore`.
 Writing DocTests
 ----------------
 
-Tests start with for spaces!
+Tests start with four spaces!
 
 ```elm
 {-| returns the sum of two int.

--- a/example/Mock.elm
+++ b/example/Mock.elm
@@ -6,10 +6,10 @@ import String
 {-| returns the sum of two int.
 
     >>> add 41 1
-    === 42
+    42
 
     >>> add 3 3
-    === 6
+    6
 
 -}
 add : Int -> Int -> Int
@@ -23,7 +23,7 @@ add =
     ...     [ 41
     ...     , 1
     ...     ]
-    === 42
+    42
 -}
 sum : List Int -> Int
 sum =
@@ -36,14 +36,14 @@ sum =
     ...     [ 41
     ...     , 1
     ...     ]
-    === [ 1
-    ... , 41
-    ... ]
+    [ 1
+    , 41
+    ]
 
     >>> rev [1, 2, 3]
     ... |> List.map toString
     ... |> String.join ""
-    === "321"
+    "321"
 -}
 rev : List a -> List a
 rev =

--- a/example/Mock/Foo/Bar/Moo.elm
+++ b/example/Mock/Foo/Bar/Moo.elm
@@ -3,7 +3,7 @@ module Mock.Foo.Bar.Moo exposing (..)
 {-| does stuff
 
     >>> foo "a" "b" "c"
-    === "bca"
+    "bca"
 -}
 
 
@@ -15,7 +15,7 @@ foo a b c =
 {-| does stuff
 
     >>> bar "a" "b" "c"
-    === [ "b", "c", "a" ]
+    [ "b", "c", "a" ]
 -}
 bar : String -> String -> String -> List String
 bar a b c =

--- a/src/DocTest/Parser.elm
+++ b/src/DocTest/Parser.elm
@@ -85,26 +85,56 @@ parseComments_ notInComment acc str =
 
 commentBegin : String -> Bool
 commentBegin str =
-    contains (regex "^{-") str
+    contains commentBeginToken str
+
+
+commentBeginToken : Regex
+commentBeginToken =
+    regex "^{-"
 
 
 commentEnd : String -> Bool
 commentEnd str =
-    contains (regex "^-}") str
+    contains commentEndToken str
+
+
+commentEndToken : Regex
+commentEndToken =
+    regex "^-}"
 
 
 replacePrefix : String -> String
 replacePrefix str =
     str
-        |> replace (AtMost 1) (regex "^\\s{4}") (\_ -> "")
-        |> replace (AtMost 1) (regex "^[>|\\.]{3}\\s") (\_ -> "")
+        |> replace (AtMost 1) fourSpaces (\_ -> "")
+        |> replace (AtMost 1) docTestPrefixes (\_ -> "")
+
+
+fourSpaces : Regex
+fourSpaces =
+    regex "^\\s{4}"
+
+
+docTestPrefixes : Regex
+docTestPrefixes =
+    regex "^[>|\\.]{3}\\s"
 
 
 continuationPrefix : String -> Bool
-continuationPrefix str =
-    contains (regex "^\\s{4}\\.\\.\\.\\s.*") str
+continuationPrefix =
+    contains continuationToken
+
+
+continuationToken : Regex
+continuationToken =
+    regex "^\\s{4}\\.\\.\\.\\s.*"
 
 
 assertionPrefix : String -> Bool
-assertionPrefix str =
-    contains (regex "^\\s{4}>>>\\s.*") str
+assertionPrefix =
+    contains assertionToken
+
+
+assertionToken : Regex
+assertionToken =
+    regex "^\\s{4}>>>\\s.*"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -42,10 +42,10 @@ import Dict
 {-| Sum
 
     >>> add 3 4
-    === 7
+    7
 
     >>> add 42 42
-    === 84
+    84
 -}
 add : Int -> Int -> Int
 add =
@@ -64,9 +64,9 @@ imports =
 comments : List String
 comments =
     [ "    >>> add 3 4"
-    , "    === 7"
+    , "    7"
     , "    >>> add 42 42"
-    , "    === 84"
+    , "    84"
     ]
 
 


### PR DESCRIPTION
proposal for new doc-test api
```diff
    >>> rev
    ...     [ 41
    ...     , 1
    ...     ]
-   === [ 1
-   ... , 41
-   ... ]
+   [ 1
+   , 41
+   ]

```

cc @eeue56 