### PR TITLE
Inline imports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,20 @@ rev =
     List.reverse
 ```
 
+You can specify imports for doc-test, if you want to use a module or a special test util.
+
+```elm
+{-| returns some html
+
+    HtmlToString is only used for doc tests.
+    >>> import HtmlToString exposing (htmlToString, nodeTypeToString)
+
+    >>> header "World"
+    ... |> htmlToString
+    "<h1>Hello, World!</h1>"
+-}
+```
+
 Running DocTests
 ----------------
 

--- a/example/Mock.elm
+++ b/example/Mock.elm
@@ -1,11 +1,11 @@
 module Mock exposing (..)
 
-import String as S exposing (join)
-import Dict
-    exposing
-        ( Dict
-        , fromList
-        )
+{-| imports for examples
+    >>> import Dict exposing (Dict, fromList)
+    >>> import String exposing (join)
+-}
+
+import Dict exposing (Dict, fromList)
 
 
 {-| returns the sum of two int.

--- a/src/DocTest/Types.elm
+++ b/src/DocTest/Types.elm
@@ -17,3 +17,4 @@ type Syntax
     = Assertion String
     | Continuation String
     | Expectation String
+    | Import String


### PR DESCRIPTION
not sure if I'm happy with this yet, though. maybe it should have it's own prefix.
see `example/Mock.elm`



closes #7 #1 