### PR TITLE
Add option to load a specific config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+# elm-doc-test generated files
+bin/elm.js
+
 # elm-package generated files
 elm-stuff
+
 # elm-repl generated files
 repl-temp-*
 

--- a/Readme.md
+++ b/Readme.md
@@ -98,6 +98,8 @@ $ elm-doc-test && elm-test tests/Doc/Main.elm
 
 By default the first command creates the tests at `tests/Doc/`. If you want to have them at a custom location use the `--output` argument (e.g. `elm-doc-test --output my/custom/path/` will create the tests at `my/custom/path/Doc/`).
 
+Also by default the first command looks for the config file at `tests/elm-doc-test.json`. If you want it to load a specific config file use the `--config` argument (e.g. `elm-doc-test --config my/custom/path/elm-doc-test.json` will read the config from `my/custom/path/elm-doc-test.json`).
+
 Examples
 --------
 

--- a/bin/cli-helpers.js
+++ b/bin/cli-helpers.js
@@ -52,13 +52,16 @@ function testsFile(tests) {
   ].join("\n");
 }
 
-function loadDocTestConfig() {
+function loadDocTestConfig(configPath=false) {
   /* load the doc test config if we can find it
      otherwise, copy the template one and load that
   */
 
-  var configPath = path.join(process.cwd(), 'tests/elm-doc-test.json');
   var docTests = null;
+  if (!configPath) {
+    configPath = path.join(process.cwd(), 'tests/elm-doc-test.json');
+  }
+
   try {
     docTests = require(configPath);
   } catch (e) {

--- a/bin/cli-helpers.js
+++ b/bin/cli-helpers.js
@@ -52,15 +52,12 @@ function testsFile(tests) {
   ].join("\n");
 }
 
-function loadDocTestConfig(configPath=false) {
+function loadDocTestConfig(configPath) {
   /* load the doc test config if we can find it
      otherwise, copy the template one and load that
   */
 
   var docTests = null;
-  if (!configPath) {
-    configPath = path.join(process.cwd(), 'tests/elm-doc-test.json');
-  }
 
   try {
     docTests = require(configPath);

--- a/bin/modes.js
+++ b/bin/modes.js
@@ -59,11 +59,12 @@ running_mode_loaders[RUNNING_MODE.RUN] = function(argv, options){
 // parse args
 function init(argv){
   var model = null;
+  var defaultConfigPath = path.join(process.cwd(), 'tests/elm-doc-test.json');
 
   var options = {
     showWarnings: true,
     output: "tests",
-    configPath: false
+    configPath: defaultConfigPath
   };
 
   if (typeof argv.warn !== "undefined") {

--- a/bin/modes.js
+++ b/bin/modes.js
@@ -26,14 +26,15 @@ running_mode_runners[RUNNING_MODE.RUN] = run;
 var running_mode_loaders = {};
 
 running_mode_loaders[RUNNING_MODE.GENERATE] = function(options){
-  var docTestConfig = helpers.loadDocTestConfig();
+  var docTestConfig = helpers.loadDocTestConfig(options.configPath);
 
   return {
     runningMode: RUNNING_MODE.GENERATE,
     config: docTestConfig,
     run: running_mode_runners[RUNNING_MODE.GENERATE],
     showWarnings: options.showWarnings,
-    output: options.output
+    output: options.output,
+    configPath: options.configPath
   };
 };
 
@@ -49,7 +50,8 @@ running_mode_loaders[RUNNING_MODE.RUN] = function(argv, options){
     config: config,
     run: running_mode_runners[RUNNING_MODE.RUN],
     showWarnings: options.showWarnings,
-    output: options.output
+    output: options.output,
+    configPath: options.configPath
   };
 };
 
@@ -60,7 +62,8 @@ function init(argv){
 
   var options = {
     showWarnings: true,
-    output: "tests"
+    output: "tests",
+    configPath: false
   };
 
   if (typeof argv.warn !== "undefined") {
@@ -69,6 +72,10 @@ function init(argv){
 
   if (typeof argv.output !== "undefined") {
     options.output = argv.output;
+  }
+
+  if (typeof argv.config !== "undefined") {
+    options.configPath = argv.config;
   }
 
   if (typeof argv.run === "undefined") {


### PR DESCRIPTION
First of all, I'm pretty sure this will become legacy code once #14 is merged. But meanwhile this could be useful for projects that do not follow a standard architecture of `src/` for Elm files and `tests/` for Elm tests.

For example, if I have my Elm files at `framework/frontend/elm/` and I'm willing to have my Elm tests at `framework/frontend/elm-tests/`:

```console
$ elm-doc-test --config framework/frontend/elm-tests/elm-doc-test.json --output framework/frontend/elm-tests/
```

To be honest I use this setup in a project in which [an Elm app lies within a bigger Django architecture](https://github.com/datasciencebr/jarbas). But maybe this might not be useful for many people. What do you think about it?