### PR TITLE
Inline comments support

### DIFF
--- a/example/Mock.elm
+++ b/example/Mock.elm
@@ -64,3 +64,15 @@ bar a b =
 rev : List a -> List a
 rev =
     List.reverse
+
+
+{-| some inline comments
+
+    >>> -- comment
+    >>> quux 10 32 -- another
+    42 --result
+
+-}
+quux : Int -> Int -> Int
+quux n m =
+    n + m

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,13 +1,14 @@
 #! /bin/bash -ex
+TEST_COUNT = cat example/tests/Doc/**/*.elm | grep 'Test.test' | wc -l
 
 elm-make src/DocTest.elm --output bin/elm.js &&
 cd example &&
 ../bin/cli.js &&
 {
-  elm-test | grep 'Passed:   10' &&
+  elm-test | grep "Passed:   $TEST_COUNT" &&
   echo "👍"
 } || {
-  echo "Expected 10 passing specs!"
+  echo "Expected $TEST_COUNT passing specs!"
   npm start
   exit -1
 }

--- a/src/DocTest/Compiler.elm
+++ b/src/DocTest/Compiler.elm
@@ -1,8 +1,8 @@
 module DocTest.Compiler exposing (compile)
 
 import DocTest.Types exposing (..)
-import String
 import Regex exposing (HowMany(..), regex)
+import String
 
 
 compile : String -> TestSuite -> String
@@ -49,8 +49,11 @@ toTest test =
     String.join "\n"
         [ indent 2 "Test.test \">>> " ++ escape test.assertion ++ "\" <|"
         , indent 3 "\\() ->"
-        , indent 4 "(" ++ test.assertion ++ ")"
-        , indent 4 "|> Expect.equal (" ++ test.expectation ++ ")"
+        , indent 4 "("
+        , indent 5 test.assertion
+        , indent 4 ") |> Expect.equal ("
+        , indent 5 test.expectation
+        , indent 4 ")"
         ]
 
 

--- a/src/DocTest/Parser.elm
+++ b/src/DocTest/Parser.elm
@@ -109,7 +109,8 @@ toTest e =
         if List.isEmpty assertion || List.isEmpty expectation then
             Nothing
         else
-            Just <| Test (String.join " " assertion) (String.join " " expectation)
+            Test (String.join " " assertion) (String.join " " expectation)
+                |> Just
 
 
 isExpectiation : Syntax -> Bool


### PR DESCRIPTION
This allows the user to write inline comments explaining the doc-test without affecting the generated test.

input:
```elm
{-| some inline comments

    >>> -- comment
    >>> quux 10 32 -- another
    42 --result

-}
quux : Int -> Int -> Int
quux n m =
    n + m
```

output:
```elm
Test.test ">>> quux 10 32 -- another" <|
    \() ->
        (
            quux 10 32 -- another
        ) |> Expect.equal (
            42 --result
        )
```

Fixes #18 